### PR TITLE
fix: refresh Catalog filters after data loads

### DIFF
--- a/src/features/catalog/components/FiltersBar.tsx
+++ b/src/features/catalog/components/FiltersBar.tsx
@@ -1,4 +1,4 @@
-import { For } from "solid-js";
+import { For, createMemo } from "solid-js";
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/ui/select";
 
 type Props = {
@@ -12,17 +12,17 @@ type Props = {
 };
 
 export default function FiltersBar(p: Props) {
-  const items = [
+  const items = createMemo(() => [
     { value: () => p.groupF, set: p.setGroupF, opts: p.groups, label: "all groups" },
     { value: () => p.truthF, set: p.setTruthF, opts: p.truths, label: "all truth values" },
     { value: () => p.posF,   set: p.setPosF,   opts: p.poss,   label: "all positions" },
     { value: () => p.morphF, set: p.setMorphF, opts: p.morphs, label: "all morphemes" },
     { value: () => p.seriesF,set: p.setSeriesF,opts: p.series, label: "all series" },
     { value: () => p.caseF,  set: p.setCaseF,  opts: p.cases,  label: "all cases" },
-  ];
+  ]);
   return (
     <div class="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-6 gap-3">
-      <For each={items}>
+      <For each={items()}>
         {(it) => (
           <Select
             value={it.value()}


### PR DESCRIPTION
## Summary
- recompute Catalog Compare filters when options change
- ensure dropdowns show groups, truth values, positions, and more once catalog data loads

## Testing
- `npm test` (fails: Missing script: "test")
- `npx tsc --noEmit`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c12cf113b0832cb2186ad2116cbca4