### PR TITLE
fix(gaze): revive charts after focus changes

### DIFF
--- a/src/components/ui/charts.tsx
+++ b/src/components/ui/charts.tsx
@@ -93,7 +93,7 @@ const BaseChart: Component<ChartProps> = (rawProps) => {
     init();
 
     const refresh = () => chart()?.resize();
-    const revive  = () => chart()?.update();
+    const revive  = () => { chart()?.resize(); chart()?.update(); };
 
     window.addEventListener("resize", refresh);
     document.addEventListener("visibilitychange", revive);


### PR DESCRIPTION
## Summary
- ensure chart resizes and updates when window visibility or focus changes

## Testing
- `npm run build`
- `npx tsc --noEmit`
- `npm run dev` *(fails: need ctrl-c to stop)*
- `npm run tauri dev` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1377f9ff4832c8cc7ca01c3e5be3f